### PR TITLE
Fix site loading error due to JS export

### DIFF
--- a/preloadLazyLoadManager.js
+++ b/preloadLazyLoadManager.js
@@ -200,4 +200,4 @@ class PreloadLazyLoadManager {
 
 const preloadLazyLoadManager = new PreloadLazyLoadManager();
 preloadLazyLoadManager.init();
-export default preloadLazyLoadManager;
+


### PR DESCRIPTION
## Summary
- remove ES module export from preloadLazyLoadManager.js

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68578da9b36c8327b76e1d843a2f2d7d