### PR TITLE
Update intersection animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,9 +197,10 @@ section {
   transform: translateY(20px);
   transition: opacity 0.6s ease-out, transform 0.6s ease-out;
 }
-section.in-view {
+.in-view {
   opacity: 1;
   transform: translateY(0);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
 }
 #home {
   background: linear-gradient(135deg, #111 0%, #222 100%);
@@ -264,11 +265,6 @@ section.in-view {
   opacity: 0;
   transform: translateY(20px);
   transition: opacity 0.6s ease-out, transform 0.6s ease-out, var(--transition);
-}
-.service-card.in-view,
-.project-card.in-view {
-  opacity: 1;
-  transform: translateY(0);
 }
 .service-card:hover,
 .project-card:hover {

--- a/intersectionAnimationManager.js
+++ b/intersectionAnimationManager.js
@@ -1,5 +1,5 @@
 class IntersectionAnimationManager {
-  constructor(selector = '.reveal', options = {}) {
+  constructor(selector = 'section, .service-card, .project-card', options = {}) {
     this.selector = selector;
     this.options = options;
     this.observer = null;
@@ -12,7 +12,7 @@ class IntersectionAnimationManager {
     if (this.remaining === 0) return;
 
     if (!('IntersectionObserver' in window)) {
-      elements.forEach(el => el.classList.add('visible'));
+      elements.forEach(el => el.classList.add('in-view'));
       return;
     }
 
@@ -23,7 +23,7 @@ class IntersectionAnimationManager {
   handleIntersect(entries, observer) {
     entries.forEach(entry => {
       if (entry.isIntersecting) {
-        entry.target.classList.add('visible');
+        entry.target.classList.add('in-view');
         observer.unobserve(entry.target);
         this.remaining--;
       }


### PR DESCRIPTION
## Summary
- observe sections and cards in `intersectionAnimationManager`
- rename visible class to `in-view`
- centralize fade/slide styles in shared `.in-view` rule

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68578fd844f48327b58eb7381f426241