### PR TITLE
Enhance hero layout and card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ body.loaded {
   justify-content: center;
   background: var(--bg);
   z-index: 9999;
-  transition: opacity 0.5s ease, visibility 0.5s ease;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
 }
 #page-loader.hidden {
   opacity: 0;
@@ -201,9 +201,13 @@ section {
 }
 #home {
   background: linear-gradient(135deg, #111 0%, #222 100%);
+  padding-top: 0;
+  margin-top: 80px;
 }
 #home .content {
   max-width: 800px;
+  position: relative;
+  z-index: 1;
 }
 .hero-banner {
   width: 100vw !important;
@@ -257,19 +261,20 @@ section {
 }
 .service-card,
 .project-card {
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 15px;
   padding: 2rem;
   backdrop-filter: blur(10px);
   opacity: 0;
   transform: translateY(20px);
-  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out, background 0.3s ease, box-shadow 0.3s ease;
 }
 .service-card:hover,
 .project-card:hover {
+  background: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.6);
   transform: translateY(-5px);
-  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
 }
 .service-icon,
 .project-icon {
@@ -284,6 +289,7 @@ section {
   object-fit: cover;
   border-radius: 10px;
   border: 2px solid var(--accent);
+  filter: brightness(1.2);
 }
 .service-card h3,
 .project-card h3 {
@@ -555,7 +561,7 @@ document.addEventListener('DOMContentLoaded', () => {
   loader.addEventListener('transitionend', () => {
     if (loader.classList.contains('hidden')) loader.remove();
   });
-  setTimeout(() => loader.classList.add('hidden'), 800);
+  setTimeout(() => loader.classList.add('hidden'), 300);
   const navToggle = document.querySelector('.nav-toggle');
   const mobileNav = document.querySelector('.mobile-nav');
   navToggle.addEventListener('click', () => {

--- a/intersectionAnimationManager.js
+++ b/intersectionAnimationManager.js
@@ -55,6 +55,7 @@ class IntersectionAnimationManager {
 function initIntersectionAnimationManager() {
   const manager = new IntersectionAnimationManager();
   manager.init();
+  document.getElementById('home').classList.add('in-view');
 }
 
 if (document.readyState === 'loading') {

--- a/styles.css
+++ b/styles.css
@@ -6,9 +6,12 @@ section {
 section::before {
   content: '';
   position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 4px;
+  top: -80px;
+  left: 0;
+  width: 100%;
+  height: 4px;
   background: var(--accent);
+  z-index: 0;
 }
 
 /* Slim full-width hero banner */
@@ -22,6 +25,16 @@ section::before {
   border-radius: 0 0 10px 10px;
 }
 
+#home {
+  padding-top: 0;
+  margin-top: 80px;
+}
+
+#home .content {
+  position: relative;
+  z-index: 1;
+}
+
 /* Remove per-element transitions and drive all fades here */
 .in-view {
   opacity: 1 !important;
@@ -32,10 +45,37 @@ section::before {
 /* Service & Project cards */
 .service-card,
 .project-card {
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(10px);
   opacity: 0;
   transform: translateY(20px);
-  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out, background 0.3s ease, box-shadow 0.3s ease;
+}
+.service-card:hover,
+.project-card:hover {
+  background: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.6);
+}
+
+.service-icon img,
+.project-icon img {
+  filter: brightness(1.2);
+}
+
+#services h2,
+#projects h2 {
+  text-align: center;
+  position: relative;
+  margin-bottom: 2rem;
+}
+#services h2::after,
+#projects h2::after {
+  content: '';
+  display: block;
+  width: 60px;
+  height: 4px;
+  background: var(--accent);
+  margin: 0.5rem auto 0;
+  border-radius: 2px;
 }


### PR DESCRIPTION
## Summary
- align hero banner flush under the header
- lift accent stripes and underline section headings
- lighten service and project cards
- boost icon brightness
- fade out page loader faster
- immediately reveal the home section on load

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68579b870ab4832798edbada5b410e83