### PR TITLE
Fix sticky header offset for section stripes

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@ body.loaded {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  height: var(--header-height);
   padding: 1rem 2rem;
   background: var(--glass-bg);
   border-bottom: 1px solid var(--glass-border);

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,7 @@
   top: 0;
   left: 0;
   width: 100%;
+  height: var(--header-height);
   z-index: 1000;
 }
 


### PR DESCRIPTION
## Summary
- ensure navbar height matches `--header-height`
- keep the CSS variable consistent in inline styles and external stylesheet

## Testing
- `npm test` *(fails: package.json missing)*
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857afeea4c08327a0a63e998e9936ed