### PR TITLE
Adjust contact banner dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,7 +423,9 @@ section::before {
 }
 .contact-banner {
   width: 100%;
-  max-width: 600px;
+  max-width: 500px;
+  max-height: 250px;
+  object-fit: cover;
   margin: 0 auto 2rem;
   border-radius: 15px;
 }


### PR DESCRIPTION
## Summary
- scale down the contact banner to a max width of 500px
- cap the banner height and use `object-fit: cover` for a slimmer appearance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857b7c5bfd48327a4328fe0e636c2b8